### PR TITLE
Refactor code and better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,12 +43,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,9 +236,8 @@ dependencies = [
 
 [[package]]
 name = "tpcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "anyhow",
  "clap",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tpcp"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+authors = ["Alejandro Gonzalvo <alejandrogonhid@gmail.com>"]
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
-anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "tpcp"
 version = "0.2.0"
+description = "Easily create a new project from a template"
 edition = "2021"
 authors = ["Alejandro Gonzalvo <alejandrogonhid@gmail.com>"]
+readme = "README.md"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # tpcp
 
+Easily create a project from a template
+
 ![Screencast-from-18-04-23-19-36-15-_online-video-cutter com_](https://user-images.githubusercontent.com/59616818/232860410-dce421d9-0119-49a1-8592-5fcb39031ecd.gif)
+
+## Usage
+
+Run `tpcp` and specify the source (template) folder and the destination (target) folder.
+
+By default this will create a new project from the template, changing the name to the name of the destination folder.
+
+To see all the options run `tpcp --help`.
+
+## Author
+
+* [Alejandro Gonzalvo](https://github.com/alejandrogonzalvo)
+
+## Contributors
+
+* [Alejandro Gonzalvo](https://github.com/alejandrogonzalvo)
+* [Juan Martinez](https://github.com/jmaralo)


### PR DESCRIPTION
This cleans up the code and adds better error handling with some messages printed to stderr.

There are two new arguments:
* placeholder: the string that will be replaced with the project name (defaults to template-project)
* name: the name of the new project (defaults to the destination folder name)

I have also updated a bit the documentation and the cargo manifest